### PR TITLE
Keep player position when toggle switch on/off

### DIFF
--- a/lib/ZPAccessory.js
+++ b/lib/ZPAccessory.js
@@ -131,7 +131,7 @@ ZPAccessory.prototype.copyCoordinator = function() {
     coordinator.becomePlatformCoordinator();
     this.log.debug("%s: copy group characteristics from %s", this.name, coordinator.name);
     if (this.state.group.on !== coordinator.state.group.on) {
-      this.log.debug("%s: set member play/stop from %s to %s", this.name,
+      this.log.debug("%s: set member play/pause from %s to %s", this.name,
                      this.state.group.on, coordinator.state.group.on);
       this.state.group.on = coordinator.state.group.on;
       this.groupService.setCharacteristic(Characteristic.On, this.state.group.on);
@@ -298,7 +298,7 @@ ZPAccessory.prototype.handleAVTransportEvent = function(data) {
       }
     }
     if (on !== this.state.group.on) {
-      this.log.info("%s: on (play/stop) changed from %s to %s", this.name, this.state.group.on, on);
+      this.log.info("%s: on (play/pause) changed from %s to %s", this.name, this.state.group.on, on);
       this.state.group.on = on;
       this.groupService.setCharacteristic(Characteristic.On, this.state.group.on);
       for (const member of this.members()) {
@@ -528,7 +528,7 @@ ZPAccessory.prototype.handleAVTransportEvent = function(data) {
     if (!this.isCoordinator) {
       return this.coordinator.setGroupOn(on, callback);
     }
-    this.log.info("%s: set on (play/stop) from %s to %s", this.name, this.state.group.on, on);
+    this.log.info("%s: set on (play/pause) from %s to %s", this.name, this.state.group.on, on);
     if (on) {
       this.log.debug("%s: play", this.name);
       this.zp.play(function(err, success) {
@@ -539,10 +539,10 @@ ZPAccessory.prototype.handleAVTransportEvent = function(data) {
         return callback();
       }.bind(this));
     } else {
-      this.log.debug("%s: stop", this.name);
-      this.zp.stop(function(err, success) {
+      this.log.debug("%s: pause", this.name);
+      this.zp.pause(function(err, success) {
         if (err || !success) {
-          this.log.error("%s: stop: %s", this.name, err);
+          this.log.error("%s: pause: %s", this.name, err);
           return callback(err);
         }
         return callback();


### PR DESCRIPTION
I'm not sure if this is by design or not. But I wanted the Sonos player toggle between play and pause instead of play and stop when using the switch in the Home app. So I can resume the track where i was when i turned the switch off.