### PR TITLE
Do not crash when parsing Airplay 2 device (sonos one)

### DIFF
--- a/lib/ZPAccessory.js
+++ b/lib/ZPAccessory.js
@@ -329,7 +329,7 @@ ZPAccessory.prototype.handleAVTransportEvent = function (data) {
         this.parser.parseString(data, (err, json) => {
           if (!err && json['DIDL-Lite']) {
             const item = json['DIDL-Lite'].item[0]
-            const type = item.res[0]._
+            const type = item.res[0]._ ? item.res[0]._ : ""
             switch (type.split(':')[0]) {
               case 'x-rincon-stream': // Line in input.
                 track = he.decode(item['dc:title'][0]) // source
@@ -364,6 +364,10 @@ ZPAccessory.prototype.handleAVTransportEvent = function (data) {
                 // track = item['dc:creator'][0] // artist
                 // track = item['upnp:album'][0] // album
                 // track = item.res[0].$.duration // duration
+                break
+              case 'x-sonosapi-hls':
+                // Skip! update will arrive in subsequent CurrentTrackMetaData events
+                // and will be handled by default case
                 break
               default:
                 if (item['dc:title']) {


### PR DESCRIPTION
When parsing DIDL-Lite it is assumed that the _ element is located in
the first element in res. This does not seem to be the case in latest
version of the sonos firmware, 9.0. This behavior is seen on a sonos
one.

To fix this crash just search for for the _ and continue as usual if
found otherwise return.