### PR TITLE
Add support for AAC radio streams

### DIFF
--- a/lib/ZpAccessory.js
+++ b/lib/ZpAccessory.js
@@ -348,6 +348,7 @@ ZpAccessory.prototype.handleAVTransportEvent = function (data) {
                 case 'x-sonosapi-vli': // Airplay2.
                   track = 'Airplay2'
                   break
+                case 'aac':               // Radio stream (e.g. DI.fm)
                 case 'x-sonosapi-stream': // Radio stream.
                 case 'x-rincon-mp3radio': // AirTunes (by homebridge-zp).
                   track = he.decode(item['r:streamContent'][0]) // info


### PR DESCRIPTION
Solves the following warning when playing a radio station using AAC compression:

[2018-11-17 12:18:21] [ZP] Kitchen Sonos: unknown track metadata {"$":{"id":"-1","parentID":"-1","restricted":"true"},"res":[{"_":"aac://http://prem2.di.fm:80/station?<DI.fm ID>","$":{"protocolInfo":"aac:*:application/octet-stream:*"}}],"r:streamContent":["Phats & Small - Turn Around"],"r:radioShowMd":[""],"dc:title":["station?<DI.fm ID>"],"upnp:class":["object.item"]}