### PR TITLE
Support streams from Amazon Music

### DIFF
--- a/lib/ZpAccessory.js
+++ b/lib/ZpAccessory.js
@@ -524,7 +524,8 @@ ZpAccessory.prototype.handleAVTransportEvent = function (data) {
                   // track = item['upnp:album'][0] // album
                   // track = item.res[0].$.duration // duration
                   break
-                case 'x-sonosapi-hls': // ??
+                case 'x-sonosapi-hls':        // ??
+                case 'x-sonosapi-hls-static': // e.g. Amazon Music
                   // Skip! update will arrive in subsequent CurrentTrackMetaData events
                   // and will be handled by default case
                   break


### PR DESCRIPTION
Solves the following warning when playing a albums from Amazon Music:

[2019-5-5 20:12:04] [Sonos] Sonos Kitchen: unknown track metadata {"$":{"id":"-1","parentID":"-1","restricted":"true"},"res":[{"_":"x-sonosapi-hls-static:catalog%2ftracks%2fB01[...]?sid=21&flags=0&sn=3","$":{"protocolInfo":"sonos.com-http:*:application/x-mpegURL:*","duration":"0:03:19"}}],"r:streamContent":[""],"r:radioShowMd":[""],"upnp:albumArtURI":["/getaa?s=1&u=x-sonosapi-hls-static%3acatalog[...]"],"dc:title":["Ein Nilpferd muss aufs WC"],"upnp:class":["object.item.audioItem.musicTrack"],"dc:creator":["Giraffenaffen Gang"],"upnp:album":["Nö mit Ö"]}

Title is read correctly afterwards, so the warning is superfluous.