### PR TITLE
Add node 14.15 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "homebridge": "^1.1.0",
-    "node": "^12.19.0"
+    "node": "^12.19.0 || ^14.15.0"
   },
   "dependencies": {
     "chalk": "^4.1.0",


### PR DESCRIPTION
Add node 14.15 compatibility since this is the new LTS version of node since 2020-10-27.

I'm using the plugin since a couple of days with the new LTS and I had no problems so far.